### PR TITLE
Bug in euclideanNormCols

### DIFF
--- a/randMatrix.cpp
+++ b/randMatrix.cpp
@@ -131,7 +131,7 @@ namespace matrixOperations{
         
         float norm = 0.0;
         for(int i = 0; i < size_l; i++){
-            norm += array[i][index] * array[i][index];
+            norm += array[index][i] * array[index][i];
         }
         return sqrt(norm);
     }

--- a/randMatrix.cpp
+++ b/randMatrix.cpp
@@ -112,7 +112,7 @@ namespace matrixOperations{
         
         float norm = 0.0;
         for(int i = 0; i < size_l; i++){
-            norm += A[index][i] * A[index][i];
+            norm += A[i][index] * A[i][index];
         }
         return sqrt(norm);
     }


### PR DESCRIPTION
The indexes need to be switched around.

Causes segmentation faults when using with non square matrices (ex: A: 10 x 10 and B: 10 x 20)
"index" is the row index.